### PR TITLE
Added onPop callback

### DIFF
--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -42,8 +42,12 @@ class FlowBuilder<T> extends StatefulWidget {
     @required this.onGeneratePages,
     this.onComplete,
     this.controller,
+    this.onPop,
   })  : assert(onGeneratePages != null),
         super(key: key);
+
+  /// Optional callback called when a pop event occurs
+  final void Function() onPop;
 
   /// Builds a [List<Page>] based on the current state.
   final OnGeneratePages<T> onGeneratePages;
@@ -135,7 +139,11 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
               _pages.removeLast();
             }
             setState(() {});
-            return route.didPop(result);
+            final didPop = route.didPop(result);
+            if (didPop) {
+              widget.onPop?.call();
+            }
+            return didPop;
           },
         ),
       ),


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
This callback gets called whenever a page is popped and can be used to notify the state manager that something has occurred.
An example of how it can be used with bloc can be found [here](https://github.com/magicleon94/flow_builder_bloc_test/blob/e166d69ae15b3c466f4b695de729d6ef887fbad4/lib/test_flow/test_flow.dart).


## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
