### PR TITLE
fix: don't lose system push route events and pass them to WidgetsBindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.2
+
+- fix: don't lose system push events and pass them to WidgetsBindings
+
 # 0.0.1
 
 - **BREAKING**: feat!: added support for null-safety

--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -362,6 +362,8 @@ abstract class _SystemNavigationObserver implements WidgetsBinding {
     switch (methodCall.method) {
       case 'popRoute':
         return _popRoute();
+      case 'pushRoute':
+        return _pushRoute(methodCall.arguments);
       default:
         return Future<dynamic>.value();
     }
@@ -373,6 +375,14 @@ abstract class _SystemNavigationObserver implements WidgetsBinding {
       if (preventDefault) return Future<dynamic>.value();
     }
     return WidgetsBinding.instance!.handlePopRoute();
+  }
+
+  static Future _pushRoute(dynamic arguments) async {
+    if (arguments is String) {
+      return WidgetsBinding.instance!.handlePushRoute(arguments);
+    } else {
+      return Future<dynamic>.value();
+    }
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter Flows made easy! A Flutter package which simplifies flows w
 repository: https://github.com/felangel/flow_builder
 homepage: https://github.com/felangel/flow_builder
 
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -625,6 +625,43 @@ void main() {
       expect(find.byKey(button2Key), findsNothing);
     });
 
+    testWidgets(
+        'system pushRoute is passed to WidgetsBinding if contains arguments',
+        (tester) async {
+      final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
+      final observer = _TestPushWidgetsBindingObserver();
+      const path = '/path';
+      widgetsBinding.addObserver(observer);
+
+      var numBuilds = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FlowBuilder<int>(
+            state: 0,
+            onGeneratePages: (state, pages) {
+              numBuilds++;
+              return <Page>[
+                const MaterialPage<void>(
+                  child: Scaffold(),
+                ),
+              ];
+            },
+          ),
+        ),
+      );
+      expect(numBuilds, 1);
+
+      await TestSystemNavigationObserver.handleSystemNavigation(
+        const MethodCall(
+          'pushRoute',
+          path,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(observer.lastRoute, path);
+      expect(observer.pushCount, 1);
+    });
+
     testWidgets('system pop does not terminate flow', (tester) async {
       const button1Key = Key('__button1__');
       const button2Key = Key('__button2__');
@@ -1010,4 +1047,15 @@ void main() {
       expect(navigators.last.observers, equals(observers));
     });
   });
+}
+
+class _TestPushWidgetsBindingObserver with WidgetsBindingObserver {
+  int pushCount = 0;
+  String? lastRoute;
+  @override
+  Future<bool> didPushRoute(String route) async {
+    lastRoute = route;
+    pushCount++;
+    return true;
+  }
 }

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -625,112 +625,117 @@ void main() {
       expect(find.byKey(button2Key), findsNothing);
     });
 
-    testWidgets(
-        'system pushRoute is passed to WidgetsBinding if contains arguments',
-        (tester) async {
-      final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
-      final observer = _TestPushWidgetsBindingObserver();
-      const path = '/path';
-      widgetsBinding.addObserver(observer);
+    group('pushRoute', () {
+      testWidgets(
+          'system pushRoute is passed to WidgetsBinding if contains arguments',
+          (tester) async {
+        final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
+        final observer = _TestPushWidgetsBindingObserver();
+        const path = '/path';
+        widgetsBinding.addObserver(observer);
 
-      var numBuilds = 0;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: FlowBuilder<int>(
-            state: 0,
-            onGeneratePages: (state, pages) {
-              numBuilds++;
-              return <Page>[
-                const MaterialPage<void>(
-                  child: Scaffold(),
-                ),
-              ];
-            },
+        var numBuilds = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FlowBuilder<int>(
+              state: 0,
+              onGeneratePages: (state, pages) {
+                numBuilds++;
+                return <Page>[
+                  const MaterialPage<void>(
+                    child: Scaffold(),
+                  ),
+                ];
+              },
+            ),
           ),
-        ),
-      );
-      expect(numBuilds, 1);
+        );
+        expect(numBuilds, 1);
 
-      await TestSystemNavigationObserver.handleSystemNavigation(
-        const MethodCall(
-          'pushRoute',
-          path,
-        ),
-      );
-      await tester.pumpAndSettle();
-      expect(observer.lastRoute, path);
-      expect(observer.pushCount, 1);
-    });
-
-    testWidgets(
-        'system pushRoute is not passed to WidgetsBinding if empty arguments',
-        (tester) async {
-      final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
-      final observer = _TestPushWidgetsBindingObserver();
-      widgetsBinding.addObserver(observer);
-
-      var numBuilds = 0;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: FlowBuilder<int>(
-            state: 0,
-            onGeneratePages: (state, pages) {
-              numBuilds++;
-              return <Page>[
-                const MaterialPage<void>(
-                  child: Scaffold(),
-                ),
-              ];
-            },
+        await TestSystemNavigationObserver.handleSystemNavigation(
+          const MethodCall(
+            'pushRoute',
+            path,
           ),
-        ),
-      );
-      expect(numBuilds, 1);
+        );
+        await tester.pumpAndSettle();
+        expect(observer.lastRoute, path);
+        expect(observer.pushCount, 1);
+        widgetsBinding.removeObserver(observer);
+      });
 
-      await TestSystemNavigationObserver.handleSystemNavigation(
-        const MethodCall(
-          'pushRoute',
-          null,
-        ),
-      );
-      await tester.pumpAndSettle();
-      expect(observer.lastRoute, isNull);
-      expect(observer.pushCount, 0);
-    });
+      testWidgets(
+          'system pushRoute is not passed to WidgetsBinding if empty arguments',
+          (tester) async {
+        final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
+        final observer = _TestPushWidgetsBindingObserver();
+        widgetsBinding.addObserver(observer);
 
-    testWidgets('other system navigation calls are not handled',
-        (tester) async {
-      final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
-      final observer = _TestPushWidgetsBindingObserver();
-      widgetsBinding.addObserver(observer);
-
-      var numBuilds = 0;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: FlowBuilder<int>(
-            state: 0,
-            onGeneratePages: (state, pages) {
-              numBuilds++;
-              return <Page>[
-                const MaterialPage<void>(
-                  child: Scaffold(),
-                ),
-              ];
-            },
+        var numBuilds = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FlowBuilder<int>(
+              state: 0,
+              onGeneratePages: (state, pages) {
+                numBuilds++;
+                return <Page>[
+                  const MaterialPage<void>(
+                    child: Scaffold(),
+                  ),
+                ];
+              },
+            ),
           ),
-        ),
-      );
-      expect(numBuilds, 1);
+        );
+        expect(numBuilds, 1);
 
-      await TestSystemNavigationObserver.handleSystemNavigation(
-        const MethodCall(
-          'randomMethod',
-          null,
-        ),
-      );
-      await tester.pumpAndSettle();
-      expect(observer.lastRoute, isNull);
-      expect(observer.pushCount, 0);
+        await TestSystemNavigationObserver.handleSystemNavigation(
+          const MethodCall(
+            'pushRoute',
+            null,
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(observer.lastRoute, isNull);
+        expect(observer.pushCount, 0);
+        widgetsBinding.removeObserver(observer);
+      });
+
+      testWidgets('other system navigation calls are not handled',
+          (tester) async {
+        final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
+        final observer = _TestPushWidgetsBindingObserver();
+        widgetsBinding.addObserver(observer);
+
+        var numBuilds = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: FlowBuilder<int>(
+              state: 0,
+              onGeneratePages: (state, pages) {
+                numBuilds++;
+                return <Page>[
+                  const MaterialPage<void>(
+                    child: Scaffold(),
+                  ),
+                ];
+              },
+            ),
+          ),
+        );
+        expect(numBuilds, 1);
+
+        await TestSystemNavigationObserver.handleSystemNavigation(
+          const MethodCall(
+            'randomMethod',
+            null,
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(observer.lastRoute, isNull);
+        expect(observer.pushCount, 0);
+        widgetsBinding.removeObserver(observer);
+      });
     });
 
     testWidgets('system pop does not terminate flow', (tester) async {

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -698,6 +698,41 @@ void main() {
       expect(observer.pushCount, 0);
     });
 
+    testWidgets('other system navigation calls are not handled',
+        (tester) async {
+      final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
+      final observer = _TestPushWidgetsBindingObserver();
+      widgetsBinding.addObserver(observer);
+
+      var numBuilds = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FlowBuilder<int>(
+            state: 0,
+            onGeneratePages: (state, pages) {
+              numBuilds++;
+              return <Page>[
+                const MaterialPage<void>(
+                  child: Scaffold(),
+                ),
+              ];
+            },
+          ),
+        ),
+      );
+      expect(numBuilds, 1);
+
+      await TestSystemNavigationObserver.handleSystemNavigation(
+        const MethodCall(
+          'randomMethod',
+          null,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(observer.lastRoute, isNull);
+      expect(observer.pushCount, 0);
+    });
+
     testWidgets('system pop does not terminate flow', (tester) async {
       const button1Key = Key('__button1__');
       const button2Key = Key('__button2__');

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -662,6 +662,42 @@ void main() {
       expect(observer.pushCount, 1);
     });
 
+    testWidgets(
+        'system pushRoute is not passed to WidgetsBinding if empty arguments',
+        (tester) async {
+      final widgetsBinding = TestWidgetsFlutterBinding.ensureInitialized();
+      final observer = _TestPushWidgetsBindingObserver();
+      widgetsBinding.addObserver(observer);
+
+      var numBuilds = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FlowBuilder<int>(
+            state: 0,
+            onGeneratePages: (state, pages) {
+              numBuilds++;
+              return <Page>[
+                const MaterialPage<void>(
+                  child: Scaffold(),
+                ),
+              ];
+            },
+          ),
+        ),
+      );
+      expect(numBuilds, 1);
+
+      await TestSystemNavigationObserver.handleSystemNavigation(
+        const MethodCall(
+          'pushRoute',
+          null,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(observer.lastRoute, isNull);
+      expect(observer.pushCount, 0);
+    });
+
     testWidgets('system pop does not terminate flow', (tester) async {
       const button1Key = Key('__button1__');
       const button2Key = Key('__button2__');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

Before this change any system push intents e.g. with new deep links would be lost on Android. This was happening when app was running in the background and new deep link was received. Now if there's any information about the deep link route, it will be passed to WidgetsBinding so that all subscribers would be able to handle it (RouterDelegate, MaterialApp, custom implementors of WidgetsBinding).

Sample implementation of custom handler:

```dart
class CustomHandler with WidgetsBindingObserver {
  CustomHandler(WidgetsBinding widgetsBinding)
      : _widgetsBinding = widgetsBinding,
        assert(widgetsBinding != null) {
    _widgetsBinding.addObserver(this);
  }

  final WidgetsBinding _widgetsBinding;

  /// Must be called when the `MaterialApp` is initialized
  /// in order to fetch the initial route.
  ///
  /// The initial route cannot be fetched before the
  /// `MaterialApp` is built for the first time.
  void initialize() {
    final route = _widgetsBinding.window.defaultRouteName;
    if (route != null) {
      // handle
    }
  }

  @override
  Future<bool> didPushRouteInformation(
      RouteInformation routeInformation) async {
    // handle
    return true;
  }

  @override
  Future<bool> didPushRoute(String route) async {
    // handle
    return true;
  }

  /// Disposes subscribing to WidgetsBinding events
  void dispose() {
    _widgetsBinding.removeObserver(this);
  }
}

```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
