### PR TITLE
fix: android back button pops the whole flow instead of popping pushed routes

### DIFF
--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -76,9 +76,9 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
   var _pages = <Page>[];
   var _didPop = false;
   final _navigatorKey = GlobalKey<NavigatorState>();
-  NavigatorState get _navigator => _navigatorKey.currentState!;
+  NavigatorState? get _navigator => _navigatorKey.currentState;
   T get _state => _controller.state;
-  bool get _canPop => _pages.length > 1;
+  bool get _canPop => _pages.length > 1 || (_navigator?.canPop() ?? false);
 
   @override
   void initState() {
@@ -131,7 +131,7 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
   Future<bool> _pop() async {
     if (mounted) {
       final navigator = _canPop ? _navigator : Navigator.of(context);
-      final willPop = await navigator.maybePop(_state);
+      final willPop = await navigator?.maybePop(_state) ?? false;
       return willPop;
     }
     return false;
@@ -164,7 +164,7 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
       child: _ConditionalWillPopScope(
         condition: _canPop,
         onWillPop: () async {
-          await _navigator.maybePop();
+          await _navigator?.maybePop();
           return false;
         },
         child: Navigator(

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -564,6 +564,66 @@ void main() {
       expect(systemPopCallCount, equals(1));
     });
 
+    testWidgets('system back button pops routes that have been pushed',
+        (tester) async {
+      var systemPopCallCount = 0;
+      SystemChannels.platform.setMockMethodCallHandler((call) {
+        if (call.method == 'SystemNavigator.pop') {
+          systemPopCallCount++;
+        }
+        return null;
+      });
+      const buttonKey = Key('__button__');
+      const scaffoldKey = Key('__scaffold__');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FlowBuilder<int>(
+            state: 0,
+            onGeneratePages: (state, pages) {
+              return <Page>[
+                MaterialPage<void>(
+                  child: Builder(
+                    builder: (context) {
+                      return Scaffold(
+                        body: TextButton(
+                          key: buttonKey,
+                          child: const Text('Button'),
+                          onPressed: () {
+                            Navigator.of(context).push<void>(MaterialPageRoute(
+                              builder: (context) => const Scaffold(
+                                key: scaffoldKey,
+                              ),
+                            ));
+                          },
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ];
+            },
+          ),
+        ),
+      );
+      expect(find.byKey(buttonKey), findsOneWidget);
+      expect(find.byKey(scaffoldKey), findsNothing);
+
+      await tester.tap(find.byKey(buttonKey));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(buttonKey), findsNothing);
+      expect(find.byKey(scaffoldKey), findsOneWidget);
+
+      await TestSystemNavigationObserver.handleSystemNavigation(
+        const MethodCall('popRoute'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(systemPopCallCount, equals(0));
+      expect(find.byKey(buttonKey), findsOneWidget);
+      expect(find.byKey(scaffoldKey), findsNothing);
+    });
+
     testWidgets('Navigator.pop pops parent route', (tester) async {
       const button1Key = Key('__button1__');
       const button2Key = Key('__button2__');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description
We've run into an issue where clicking the android back button in a route that has been pushed from a  page in a flow builder cancels the flow.

Example ([`example`](https://github.com/kirpal/flow_builder/tree/example)):
1. Tap "Authentication Flow"
2. Tap "Settings", which pushes a route using: `Navigator.of(context).push(SettingsPage.route());`
3. Tap android back button
    - Expected: pop `SettingsPage`, go back to `SplashPage`
    - Actual: pops the base `FlowBuilder` and goes to app home
    
[Example with fix applied](https://github.com/kirpal/flow_builder/tree/example-fixed)
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
