### PR TITLE
feat: add parameter names to OnGeneratePages

### DIFF
--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 
 /// Signature for function which generates a [List<Page>] given an input of [T]
 /// and the current [List<Page>].
-typedef OnGeneratePages<T> = List<Page> Function(T, List<Page>);
+typedef OnGeneratePages<T> = List<Page> Function(T state, List<Page> pages);
 
 /// Signature for function which given an input flow state [T] will
 /// output a new flow state [T].


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Convenience update to identify typedef function parameters when IDE supports auto-completion.
Before (IntelliJ): `(p0, p1) => ...`
After: `(state, pages) => ...`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
