### PR TITLE
fix: no pop when it is not at top

### DIFF
--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -135,7 +135,7 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
   }
 
   Future<bool> _pop() async {
-    if (mounted) {
+    if (mounted && (ModalRoute.of(context)?.isCurrent ?? false)) {
       final popHandled = await _navigator?.maybePop(_state) ?? false;
       if (popHandled) return true;
       if (!_canPop) return await Navigator.of(context).maybePop(_state);


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

fix #84 #77 

This prevent popping when another modal is on top of flow builder


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
