### PR TITLE
fix: [example] rename `DropDownMenu` to `DropDownMenuButton` to fix widget naming conflicts

### DIFF
--- a/example/lib/location_flow/pages/city_selection/city_selection.dart
+++ b/example/lib/location_flow/pages/city_selection/city_selection.dart
@@ -43,7 +43,7 @@ class CitySelectionForm extends StatelessWidget {
                   case LocationStatus.loading:
                     return const LoadingIndicator();
                   case LocationStatus.success:
-                    return DropdownMenu(
+                    return DropdownMenuButton(
                       hint: const Text('Select a City'),
                       items: state.locations,
                       value: state.selectedLocation,

--- a/example/lib/location_flow/pages/country_selection/country_selection.dart
+++ b/example/lib/location_flow/pages/country_selection/country_selection.dart
@@ -47,7 +47,7 @@ class CountrySelectionForm extends StatelessWidget {
                   case LocationStatus.loading:
                     return const LoadingIndicator();
                   case LocationStatus.success:
-                    return DropdownMenu(
+                    return DropdownMenuButton(
                       hint: const Text('Select a Country'),
                       items: state.locations,
                       value: state.selectedLocation,

--- a/example/lib/location_flow/pages/state_selection/state_selection.dart
+++ b/example/lib/location_flow/pages/state_selection/state_selection.dart
@@ -43,7 +43,7 @@ class StateSelectionForm extends StatelessWidget {
                   case LocationStatus.loading:
                     return const LoadingIndicator();
                   case LocationStatus.success:
-                    return DropdownMenu(
+                    return DropdownMenuButton(
                       hint: const Text('Select a State'),
                       items: state.locations,
                       value: state.selectedLocation,

--- a/example/lib/location_flow/widgets/drop_down_menu_button.dart
+++ b/example/lib/location_flow/widgets/drop_down_menu_button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class DropdownMenu extends StatelessWidget {
-  const DropdownMenu({
+class DropdownMenuButton extends StatelessWidget {
+  const DropdownMenuButton({
     super.key,
     required this.items,
     required this.onChanged,

--- a/example/lib/location_flow/widgets/widgets.dart
+++ b/example/lib/location_flow/widgets/widgets.dart
@@ -1,3 +1,3 @@
-export 'drop_down_menu.dart';
+export 'drop_down_menu_button.dart';
 export 'loading_indicator.dart';
 export 'location_error.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Fixes naming conflict at `location_flow` example.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
