### PR TITLE
feat!: replace deprecated `WillPopScope` with `PopScope`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 3.13.9
+      flutter_version: 3.19.5
 
   pana:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/pana.yml@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0
+
+- **BREAKING**: replace deprecated `WillPopScope` with `PopScope`
+- refactor: update to Flutter >=3.16.0, dart >=3.2.0 
+
 # 0.0.10
 
 - feat: add optional `clipBehavior` ([#113](https://github.com/felangel/flow_builder/pull/113))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# 1.0.0
+# 0.1.0
 
 - **BREAKING**: replace deprecated `WillPopScope` with `PopScope`
-- refactor: update to Flutter >=3.16.0, dart >=3.2.0 
+- refactor: update dart sdk constrant to `>=3.2.0`
 
 # 0.0.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 0.1.0
 
 - **BREAKING**: replace deprecated `WillPopScope` with `PopScope`
-- refactor: update dart sdk constrant to `>=3.2.0`
+  - refactor: update dart sdk constrant to `>=3.2.0`
+  - refactor: update flutter constraint to `>=3.16.0`
 
 # 0.0.10
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,14 +22,9 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class Home extends StatefulWidget {
+class Home extends StatelessWidget {
   const Home({super.key});
 
-  @override
-  State<Home> createState() => _HomeState();
-}
-
-class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -44,7 +39,7 @@ class _HomeState extends State<Home> {
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () async {
                   await Navigator.of(context).push(OnboardingFlow.route());
-                  if (!mounted) return;
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context)
                     ..hideCurrentSnackBar()
                     ..showSnackBar(
@@ -62,7 +57,7 @@ class _HomeState extends State<Home> {
                   final profile = await Navigator.of(context).push(
                     ProfileFlow.route(),
                   );
-                  if (!mounted) return;
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context)
                     ..hideCurrentSnackBar()
                     ..showSnackBar(
@@ -80,7 +75,7 @@ class _HomeState extends State<Home> {
                   final location = await Navigator.of(context).push(
                     LocationFlow.route(),
                   );
-                  if (!mounted) return;
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context)
                     ..hideCurrentSnackBar()
                     ..showSnackBar(
@@ -98,7 +93,7 @@ class _HomeState extends State<Home> {
                   await Navigator.of(context).push<AuthenticationState>(
                     AuthenticationFlow.route(),
                   );
-                  if (!mounted) return;
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context)
                     ..hideCurrentSnackBar()
                     ..showSnackBar(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.0

--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -178,7 +178,6 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
       controller: _controller,
       child: _ConditionalPopScope(
         condition: _canPop,
-        onPopInvoked: (bool _) => _navigator?.maybePop(),
         child: Navigator(
           key: _navigatorKey,
           pages: _pages,
@@ -330,23 +329,15 @@ class FakeFlowController<T> extends FlowController<T> {
 class _ConditionalPopScope extends StatelessWidget {
   const _ConditionalPopScope({
     required this.condition,
-    required this.onPopInvoked,
     required this.child,
   });
 
   final bool condition;
   final Widget child;
-  final PopInvokedCallback onPopInvoked;
 
   @override
   Widget build(BuildContext context) {
-    return condition
-        ? PopScope(
-            canPop: false,
-            onPopInvoked: onPopInvoked,
-            child: child,
-          )
-        : child;
+    return condition ? PopScope(canPop: false, child: child) : child;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/flow_builder
 homepage: https://github.com/felangel/flow_builder
 topics: [navigation, routing]
 
-version: 0.0.10
+version: 0.1.0
 
 environment:
   sdk: ">=3.2.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,12 +2,13 @@ name: flow_builder
 description: Flutter Flows made easy! A Flutter package which simplifies flows with a flexible, declarative API.
 repository: https://github.com/felangel/flow_builder
 homepage: https://github.com/felangel/flow_builder
-topics: [navigation, routing]
+topics: [ navigation, routing ]
 
 version: 0.0.10
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ^3.2.0
+  flutter: ^3.16.0
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,13 +2,12 @@ name: flow_builder
 description: Flutter Flows made easy! A Flutter package which simplifies flows with a flexible, declarative API.
 repository: https://github.com/felangel/flow_builder
 homepage: https://github.com/felangel/flow_builder
-topics: [ navigation, routing ]
+topics: [navigation, routing]
 
 version: 0.0.10
 
 environment:
-  sdk: ^3.2.0
-  flutter: ^3.16.0
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ version: 0.1.0
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.16.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -1388,7 +1388,7 @@ void main() {
       expect(navigators.last.observers, equals(observers));
     });
 
-    testWidgets('SystemNavigator.pop respects when PopScope(canPop: false)',
+    testWidgets('SystemNavigator.pop respects PopScope(canPop: false)',
         (tester) async {
       const targetKey = Key('__target__');
       var onPopCallCount = 0;
@@ -1442,7 +1442,7 @@ void main() {
       expect(find.byKey(targetKey), findsOneWidget);
     });
 
-    testWidgets('SystemNavigator.pop respects when PopScope(canPop: true)',
+    testWidgets('SystemNavigator.pop respects PopScope(canPop: true)',
         (tester) async {
       const targetKey = Key('__target__');
       var onPopCallCount = 0;

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -1063,7 +1063,7 @@ void main() {
       expect(find.byKey(button2Key), findsOneWidget);
     });
 
-    testWidgets('onWillPop pops top page when there are multiple',
+    testWidgets('Navigator.pop pops top page when there are multiple',
         (tester) async {
       const button1Key = Key('__button1__');
       const button2Key = Key('__button2__');
@@ -1084,10 +1084,14 @@ void main() {
                 ),
                 MaterialPage<void>(
                   child: Scaffold(
-                    body: TextButton(
-                      key: button2Key,
-                      child: const Text('Button'),
-                      onPressed: () {},
+                    body: Builder(
+                      builder: (context) {
+                        return TextButton(
+                          key: button2Key,
+                          child: const Text('Button'),
+                          onPressed: () => Navigator.of(context).pop(),
+                        );
+                      },
                     ),
                   ),
                 ),
@@ -1100,19 +1104,14 @@ void main() {
       expect(find.byKey(button1Key), findsNothing);
       expect(find.byKey(button2Key), findsOneWidget);
 
-      final willPopScope = tester.widget<WillPopScope>(
-        find.byType(WillPopScope),
-      );
-      final result = await willPopScope.onWillPop!();
-      expect(result, isFalse);
-
+      await tester.tap(find.byKey(button2Key));
       await tester.pumpAndSettle();
 
       expect(find.byKey(button1Key), findsOneWidget);
       expect(find.byKey(button2Key), findsNothing);
     });
 
-    testWidgets('onWillPop does not exist for only one page', (tester) async {
+    testWidgets('PopScope does not exist for only one page', (tester) async {
       const button1Key = Key('__button1__');
       await tester.pumpWidget(
         MaterialApp(
@@ -1136,7 +1135,7 @@ void main() {
       );
 
       expect(find.byKey(button1Key), findsOneWidget);
-      expect(find.byType(WillPopScope), findsNothing);
+      expect(find.byType(PopScope), findsNothing);
     });
 
     testWidgets('controller change triggers a rebuild with correct state',
@@ -1389,21 +1388,19 @@ void main() {
       expect(navigators.last.observers, equals(observers));
     });
 
-    testWidgets('SystemNavigator.pop respects when WillPopScope returns false',
+    testWidgets('SystemNavigator.pop respects when PopScope(canPop: false)',
         (tester) async {
       const targetKey = Key('__target__');
-      var onWillPopCallCount = 0;
+      var onPopCallCount = 0;
       final flow = FlowBuilder<int>(
         state: 0,
         onGeneratePages: (state, pages) {
           return <Page<dynamic>>[
             MaterialPage<void>(
               child: Builder(
-                builder: (context) => WillPopScope(
-                  onWillPop: () async {
-                    onWillPopCallCount++;
-                    return false;
-                  },
+                builder: (context) => PopScope(
+                  canPop: false,
+                  onPopInvoked: (_) => onPopCallCount++,
                   child: TextButton(
                     key: targetKey,
                     onPressed: () {
@@ -1441,24 +1438,23 @@ void main() {
       await tester.tap(find.byKey(targetKey));
       await tester.pumpAndSettle();
 
-      expect(onWillPopCallCount, equals(1));
+      expect(onPopCallCount, equals(1));
       expect(find.byKey(targetKey), findsOneWidget);
     });
 
-    testWidgets('SystemNavigator.pop respects when WillPopScope returns true',
+    testWidgets('SystemNavigator.pop respects when PopScope(canPop: true)',
         (tester) async {
       const targetKey = Key('__target__');
-      var onWillPopCallCount = 0;
+      var onPopCallCount = 0;
       final flow = FlowBuilder<int>(
         state: 0,
         onGeneratePages: (state, pages) {
           return <Page<dynamic>>[
             MaterialPage<void>(
               child: Builder(
-                builder: (context) => WillPopScope(
-                  onWillPop: () async {
-                    onWillPopCallCount++;
-                    return true;
+                builder: (context) => PopScope(
+                  onPopInvoked: (_) {
+                    onPopCallCount++;
                   },
                   child: TextButton(
                     key: targetKey,
@@ -1497,7 +1493,7 @@ void main() {
       await tester.tap(find.byKey(targetKey));
       await tester.pumpAndSettle();
 
-      expect(onWillPopCallCount, equals(1));
+      expect(onPopCallCount, equals(1));
       expect(find.byKey(targetKey), findsNothing);
     });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

This PR introduces replacing [deprecated](https://docs.flutter.dev/release/breaking-changes/android-predictive-back) `WillPopScope` with `PopScope`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
