### PR TITLE
fix: SystemNavigator.pop respects PopScope(canPop: true)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1
+
+- fix: SystemNavigator.pop respects PopScope(canPop: true)
+
 # 0.1.0
 
 - **BREAKING**: replace deprecated `WillPopScope` with `PopScope`

--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -149,7 +149,12 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
     if (mounted) {
       final popHandled = await _navigator?.maybePop() ?? false;
       if (popHandled) return true;
-      if (mounted && !_canPop) _navigator?.pop();
+      if (mounted && !_canPop) {
+        // call onPopInvoked if any
+        _navigator?.pop();
+        // really navigate
+        return Navigator.of(context).maybePop();
+      }
       return false;
     }
     return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/flow_builder
 homepage: https://github.com/felangel/flow_builder
 topics: [navigation, routing]
 
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=3.2.0 <4.0.0"


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

This PR fixes 1st page in the Flow `SystemNavigator.pop` for Android.
During migration from `WillPopScope` to `PopScope` (v.0.1.0) there was missed a bug that reproduces on Androids `SystemNavigator.pop`:
- push the Flow with only one page in the stack that contains `PopScope(canPop: true)`
- call `SystemNavigator.pop`
- the screen is empty (Flow is in the stack, but flow doesn't have pages)

Proposed fix:
- call `_navigator?.pop();` to call `onPopInvoked`
- then call `Navigator.of(context).maybePop()` for real navigation as in previous version of the package

This fix doesn't look like ideal, but it works and I haven't find other way to call `onPopInvoked`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
