### PR TITLE
test: Add test helpers for system navigation

### DIFF
--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -381,12 +381,3 @@ abstract class _SystemNavigationObserver implements WidgetsBinding {
     }
   }
 }
-
-/// Visible for testing system navigation.
-abstract class TestSystemNavigationObserver {
-  /// Visible for testing system pop navigation.
-  @visibleForTesting
-  static Future<dynamic> handleSystemNavigation(MethodCall methodCall) {
-    return _SystemNavigationObserver._handleSystemNavigation(methodCall);
-  }
-}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

This PR adds extension methods on WidgetTester that allow to simulate system navigation events in tests. This change makes the tests more robust because they simulate the underlying platform message instead of calling the test wrapper for `_SystemNavigationObserver`. It also makes the potential removal of `_SystemNavigationObserver` in the future easier.

Found this in the tests of the `go_router` package [here](https://github.com/flutter/packages/blob/main/packages/go_router/test/test_helpers.dart)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Testing
