### PR TITLE
refactor: replace onPopPage with onDidRemovePage in Navigator

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 3.19.5
+      flutter_version: 3.24.0
 
   pana:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/pana.yml@v1

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:very_good_analysis/analysis_options.5.1.0.yaml
+include: package:very_good_analysis/analysis_options.6.0.0.yaml

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:very_good_analysis/analysis_options.5.1.0.yaml
+include: package:very_good_analysis/analysis_options.6.0.0.yaml
 linter:
   rules:
     public_member_api_docs: false

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_bloc: ^8.0.0
 
 dev_dependencies:
-  very_good_analysis: ^5.1.0
+  very_good_analysis: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   bloc: ^8.0.0

--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -184,7 +184,7 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
           pages: _pages,
           observers: widget.observers,
           clipBehavior: widget.clipBehavior,
-          onPopPage: (route, dynamic result) {
+          onDidRemovePage: (page) {
             if (_history.length > 1) {
               _history.removeLast();
               _didPop = true;
@@ -194,8 +194,7 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
               _pages.removeLast();
             }
             setState(() {});
-            route.onPopInvoked(true);
-            return route.didPop(result);
+            page.onPopInvoked(true, null);
           },
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^5.1.0
+  very_good_analysis: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ funding: [https://github.com/sponsors/felangel]
 version: 0.1.0
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/test/flow_builder_test.dart
+++ b/test/flow_builder_test.dart
@@ -1389,7 +1389,7 @@ void main() {
               child: Builder(
                 builder: (context) => PopScope(
                   canPop: false,
-                  onPopInvoked: (_) => onPopCallCount++,
+                  onPopInvokedWithResult: (_, __) => onPopCallCount++,
                   child: TextButton(
                     key: targetKey,
                     onPressed: () {
@@ -1440,9 +1440,7 @@ void main() {
             MaterialPage<void>(
               child: Builder(
                 builder: (context) => PopScope(
-                  onPopInvoked: (_) {
-                    onPopCallCount++;
-                  },
+                  onPopInvokedWithResult: (_, __) => onPopCallCount++,
                   child: TextButton(
                     key: targetKey,
                     onPressed: () {


### PR DESCRIPTION
In Navigator, onPopPage method was deprecated after `v3.16.0-17.0.pre`. The suggested method is `onDidRemovePage`.

## Status

READY

## Breaking Changes

NO

## Description

Change deprecated method to the new one.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
